### PR TITLE
Terminal rules and Composition rules

### DIFF
--- a/core/src/builder.rs
+++ b/core/src/builder.rs
@@ -107,7 +107,24 @@ impl<StashValue: NodePayload> RuleSetBuilder<StashValue> {
             .push(Box::new(Rule3::new(sym, (pa, pb, pc), production)))
     }
 
-    
+    pub fn rule_3_terminal<S, PA, PB, PC, V, F>(&self, sym: S, pa: PA, pb: PB, pc: PC, production: F)
+        where S: Into<String> + AsRef<str>,
+              V: NodePayload<Payload=StashValue::Payload> + 'static,
+              StashValue: From<V> + 'static,
+              F: for<'a> Fn(&RuleProductionArg<'a, PA::M>,
+                            &RuleProductionArg<'a, PB::M>,
+                            &RuleProductionArg<'a, PC::M>)
+                            -> RuleResult<V> + 'static + Send + Sync,
+              PA: TerminalPattern<StashValue> + 'static,
+              PB: TerminalPattern<StashValue> + 'static,
+              PC: TerminalPattern<StashValue> + 'static
+    {
+        let sym = self.sym(sym);
+        self.composition_rules
+            .borrow_mut()
+            .push(Box::new(Rule3::new(sym, (pa, pb, pc), production)))
+    }
+
     pub fn rule_4<S, PA, PB, PC, PD, V, F>(&self, sym: S, pa: PA, pb: PB, pc: PC, pd: PD, production: F)
         where S: Into<String> + AsRef<str>,
               V: NodePayload<Payload=StashValue::Payload> + 'static,
@@ -128,7 +145,26 @@ impl<StashValue: NodePayload> RuleSetBuilder<StashValue> {
             .push(Box::new(Rule4::new(sym, (pa, pb, pc, pd), production)))
     }
 
-    
+    pub fn rule_4_terminal<S, PA, PB, PC, PD, V, F>(&self, sym: S, pa: PA, pb: PB, pc: PC, pd: PD, production: F)
+        where S: Into<String> + AsRef<str>,
+              V: NodePayload<Payload=StashValue::Payload> + 'static,
+              StashValue: From<V> + 'static,
+              F: for<'a> Fn(&RuleProductionArg<'a, PA::M>,
+                            &RuleProductionArg<'a, PB::M>,
+                            &RuleProductionArg<'a, PC::M>,
+                            &RuleProductionArg<'a, PD::M>)
+                            -> RuleResult<V> + 'static + Send + Sync,
+              PA: TerminalPattern<StashValue> + 'static,
+              PB: TerminalPattern<StashValue> + 'static,
+              PC: TerminalPattern<StashValue> + 'static,
+              PD: TerminalPattern<StashValue> + 'static,
+    {
+        let sym = self.sym(sym);
+        self.composition_rules
+            .borrow_mut()
+            .push(Box::new(Rule4::new(sym, (pa, pb, pc, pd), production)))
+    }
+
     pub fn rule_5<S, PA, PB, PC, PD, PE, V, F>(&self, sym: S, pa: PA, pb: PB, pc: PC, pd: PD, pe: PE, production: F)
         where S: Into<String> + AsRef<str>,
               V: NodePayload<Payload=StashValue::Payload> + 'static,
@@ -144,6 +180,28 @@ impl<StashValue: NodePayload> RuleSetBuilder<StashValue> {
               PC: Pattern<StashValue> + 'static,
               PD: Pattern<StashValue> + 'static,
               PE: Pattern<StashValue> + 'static,
+    {
+        let sym = self.sym(sym);
+        self.composition_rules
+            .borrow_mut()
+            .push(Box::new(Rule5::new(sym, (pa, pb, pc, pd, pe), production)))
+    }
+
+    pub fn rule_5_terminal<S, PA, PB, PC, PD, PE, V, F>(&self, sym: S, pa: PA, pb: PB, pc: PC, pd: PD, pe: PE, production: F)
+        where S: Into<String> + AsRef<str>,
+              V: NodePayload<Payload=StashValue::Payload> + 'static,
+              StashValue: From<V> + 'static,
+              F: for<'a> Fn(&RuleProductionArg<'a, PA::M>,
+                            &RuleProductionArg<'a, PB::M>,
+                            &RuleProductionArg<'a, PC::M>,
+                            &RuleProductionArg<'a, PD::M>,
+                            &RuleProductionArg<'a, PE::M>)
+                            -> RuleResult<V> + 'static + Send + Sync,
+              PA: TerminalPattern<StashValue> + 'static,
+              PB: TerminalPattern<StashValue> + 'static,
+              PC: TerminalPattern<StashValue> + 'static,
+              PD: TerminalPattern<StashValue> + 'static,
+              PE: TerminalPattern<StashValue> + 'static,
     {
         let sym = self.sym(sym);
         self.composition_rules
@@ -168,6 +226,30 @@ impl<StashValue: NodePayload> RuleSetBuilder<StashValue> {
               PD: Pattern<StashValue> + 'static,
               PE: Pattern<StashValue> + 'static,
               PF: Pattern<StashValue> + 'static,
+    {
+        let sym = self.sym(sym);
+        self.composition_rules
+            .borrow_mut()
+            .push(Box::new(Rule6::new(sym, (pa, pb, pc, pd, pe, pf), production)))
+    }
+
+    pub fn rule_6_terminal<S, PA, PB, PC, PD, PE, PF, V, F>(&self, sym: S, pa: PA, pb: PB, pc: PC, pd: PD, pe: PE, pf: PF, production: F)
+        where S: Into<String> + AsRef<str>,
+              V: NodePayload<Payload=StashValue::Payload> + 'static,
+              StashValue: From<V> + 'static,
+              F: for<'a> Fn(&RuleProductionArg<'a, PA::M>,
+                            &RuleProductionArg<'a, PB::M>,
+                            &RuleProductionArg<'a, PC::M>,
+                            &RuleProductionArg<'a, PD::M>,
+                            &RuleProductionArg<'a, PE::M>,
+                            &RuleProductionArg<'a, PF::M>)
+                            -> RuleResult<V> + 'static + Send + Sync,
+              PA: TerminalPattern<StashValue> + 'static,
+              PB: TerminalPattern<StashValue> + 'static,
+              PC: TerminalPattern<StashValue> + 'static,
+              PD: TerminalPattern<StashValue> + 'static,
+              PE: TerminalPattern<StashValue> + 'static,
+              PF: TerminalPattern<StashValue> + 'static,
     {
         let sym = self.sym(sym);
         self.composition_rules

--- a/core/src/builder.rs
+++ b/core/src/builder.rs
@@ -1,6 +1,6 @@
 use cell;
 
-use {CoreResult, Pattern, RuleSet, Sym, SymbolTable, NodePayload};
+use {CoreResult, Pattern, TerminalPattern, RuleSet, Sym, SymbolTable, NodePayload};
 use pattern;
 use helpers::BoundariesChecker;
 use rule::{Rule, Rule1, Rule2, Rule3, Rule4, Rule5, Rule6, RuleProductionArg};
@@ -41,9 +41,21 @@ impl<StashValue: NodePayload> RuleSetBuilder<StashValue> {
         let sym = self.sym(sym);
         self.rules
             .borrow_mut()
-            .push(Box::new(Rule1::new(sym, pa, production)))
+            .push(Box::new(Rule1::new(sym, false, pa, production)))
     }
 
+    pub fn rule_1_terminal<S, PA, V, F>(&self, sym: S, pa: PA, production: F)
+        where S: Into<String> + AsRef<str>,
+              V: NodePayload<Payload=StashValue::Payload> + 'static,
+              StashValue: From<V> + 'static,
+              F: for<'a> Fn(&RuleProductionArg<'a, PA::M>) -> RuleResult<V> + 'static + Send + Sync,
+              PA: TerminalPattern<StashValue> + 'static
+    {
+        let sym = self.sym(sym);
+        self.rules
+            .borrow_mut()
+            .push(Box::new(Rule1::new(sym, true, pa, production)))
+    }
     
     pub fn rule_2<S, PA, PB, V, F>(&self, sym: S, pa: PA, pb: PB, production: F)
         where S: Into<String> + AsRef<str>,
@@ -57,10 +69,23 @@ impl<StashValue: NodePayload> RuleSetBuilder<StashValue> {
         let sym = self.sym(sym);
         self.rules
             .borrow_mut()
-            .push(Box::new(Rule2::new(sym, (pa, pb), production)))
+            .push(Box::new(Rule2::new(sym, false, (pa, pb), production)))
     }
 
-    
+    pub fn rule_2_terminal<S, PA, PB, V, F>(&self, sym: S, pa: PA, pb: PB, production: F)
+        where S: Into<String> + AsRef<str>,
+              V: NodePayload<Payload=StashValue::Payload> + 'static,
+              StashValue: From<V> + 'static,
+              F: for<'a> Fn(&RuleProductionArg<'a, PA::M>, &RuleProductionArg<'a, PB::M>)
+                            -> RuleResult<V> + 'static + Send + Sync,
+              PA: TerminalPattern<StashValue> + 'static,
+              PB: TerminalPattern<StashValue> + 'static
+    {
+        let sym = self.sym(sym);
+        self.rules
+            .borrow_mut()
+            .push(Box::new(Rule2::new(sym, true, (pa, pb), production)))
+    }
 
     pub fn rule_3<S, PA, PB, PC, V, F>(&self, sym: S, pa: PA, pb: PB, pc: PC, production: F)
         where S: Into<String> + AsRef<str>,
@@ -77,7 +102,7 @@ impl<StashValue: NodePayload> RuleSetBuilder<StashValue> {
         let sym = self.sym(sym);
         self.rules
             .borrow_mut()
-            .push(Box::new(Rule3::new(sym, (pa, pb, pc), production)))
+            .push(Box::new(Rule3::new(sym, false, (pa, pb, pc), production)))
     }
 
     
@@ -98,7 +123,7 @@ impl<StashValue: NodePayload> RuleSetBuilder<StashValue> {
         let sym = self.sym(sym);
         self.rules
             .borrow_mut()
-            .push(Box::new(Rule4::new(sym, (pa, pb, pc, pd), production)))
+            .push(Box::new(Rule4::new(sym, false, (pa, pb, pc, pd), production)))
     }
 
     
@@ -121,7 +146,7 @@ impl<StashValue: NodePayload> RuleSetBuilder<StashValue> {
         let sym = self.sym(sym);
         self.rules
             .borrow_mut()
-            .push(Box::new(Rule5::new(sym, (pa, pb, pc, pd, pe), production)))
+            .push(Box::new(Rule5::new(sym, false, (pa, pb, pc, pd, pe), production)))
     }
 
     
@@ -146,7 +171,7 @@ impl<StashValue: NodePayload> RuleSetBuilder<StashValue> {
         let sym = self.sym(sym);
         self.rules
             .borrow_mut()
-            .push(Box::new(Rule6::new(sym, (pa, pb, pc, pd, pe, pf), production)))
+            .push(Box::new(Rule6::new(sym, false, (pa, pb, pc, pd, pe, pf), production)))
     }
     
     pub fn reg(&self, regex:&str) -> CoreResult<pattern::TextPattern<StashValue>> {

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -20,6 +20,7 @@ mod helpers;
 
 use rule::Rule;
 use pattern::Pattern;
+use pattern::TerminalPattern;
 pub use range::Range;
 pub use rule::rule_errors::*;
 pub use builder::RuleSetBuilder;

--- a/core/src/pattern.rs
+++ b/core/src/pattern.rs
@@ -70,6 +70,7 @@ pub trait Pattern<StashValue: NodePayload>: Send + Sync {
                  -> CoreResult<PredicateMatches<Self::M>>;
 }
 
+pub trait TerminalPattern<StashValue: NodePayload>: Pattern<StashValue, M=Text<StashValue>> { }
 
 pub struct TextPattern<StashValue: NodePayload> {
     pattern: ::regex::Regex, 
@@ -132,6 +133,8 @@ impl<StashValue: NodePayload> Pattern<StashValue> for TextPattern<StashValue> {
         Ok(results)
     }
 }
+
+impl<StashValue: NodePayload> TerminalPattern<StashValue> for TextPattern<StashValue> {}
 
 pub struct TextNegLHPattern<StashValue: NodePayload> {
     pattern: ::regex::Regex,
@@ -205,6 +208,8 @@ impl<StashValue: NodePayload> Pattern<StashValue> for TextNegLHPattern<StashValu
         Ok(results)
     }
 }
+
+impl<StashValue: NodePayload> TerminalPattern<StashValue> for TextNegLHPattern<StashValue> {}
 
 pub type AnyNodePattern<V> = FilterNodePattern<V>;
 

--- a/core/src/rule.rs
+++ b/core/src/rule.rs
@@ -79,6 +79,7 @@ pub trait Rule<StashValue: NodePayload>: Send + Sync {
              stash: &Stash<StashValue>,
              sentence: &str)
              -> CoreResult<ParsedNodes<StashValue>>;
+    fn is_terminal(&self) -> bool;
 }
 
 pub struct Rule1<PA, V, StashValue, F>
@@ -90,6 +91,7 @@ pub struct Rule1<PA, V, StashValue, F>
     sym: Sym,
     pattern: PA,
     production: F,
+    is_terminal: bool,
     _phantom: SendSyncPhantomData<(V, StashValue)>,
 }
 
@@ -132,6 +134,10 @@ impl<PA, V, StashValue, F> Rule<StashValue> for Rule1<PA, V, StashValue, F>
             })
             .collect()
     }
+
+    fn is_terminal(&self) -> bool {
+        self.is_terminal
+    }
 }
 
 impl<PA, V, StashValue, F> Rule1<PA, V, StashValue, F>
@@ -140,9 +146,10 @@ impl<PA, V, StashValue, F> Rule1<PA, V, StashValue, F>
           F: for<'a> Fn(&RuleProductionArg<'a, PA::M>) -> RuleResult<V>,
           PA: Pattern<StashValue>
 {
-    pub fn new(sym: Sym, pat: PA, prod: F) -> Rule1<PA, V, StashValue, F> {
+    pub fn new(sym: Sym, is_terminal: bool, pat: PA, prod: F) -> Rule1<PA, V, StashValue, F> {
         Rule1 {
             sym: sym,
+            is_terminal: is_terminal,
             pattern: pat,
             production: prod,
             _phantom: SendSyncPhantomData::new(),
@@ -167,6 +174,7 @@ pub struct Rule2<PA, PB, V, StashValue, F>
           PB: Pattern<StashValue>,
 {
     sym: Sym,
+    is_terminal: bool,
     pattern: (PA, PB),
     production: F,
     _phantom: SendSyncPhantomData<(V,  StashValue)>,
@@ -211,6 +219,10 @@ impl<PA, PB, V, StashValue, F> Rule<StashValue>
             })
             .collect()
     }
+
+    fn is_terminal(&self) -> bool {
+        self.is_terminal
+    }
 }
 
 impl<PA, PB, V, StashValue, F> Rule2<PA, PB, V, StashValue, F>
@@ -221,11 +233,13 @@ impl<PA, PB, V, StashValue, F> Rule2<PA, PB, V, StashValue, F>
           PB: Pattern<StashValue>,
 {
     pub fn new(sym: Sym,
+               is_terminal: bool,
                pat: (PA, PB),
-               prod: F)
+               prod: F,)
                -> Rule2<PA, PB, V, StashValue, F> {
         Rule2 {
             sym: sym,
+            is_terminal: is_terminal,
             pattern: pat,
             production: prod,
             _phantom: SendSyncPhantomData::new(),
@@ -263,6 +277,7 @@ pub struct Rule3<PA, PB, PC, V, StashValue, F>
           PC: Pattern<StashValue>,
 {
     sym: Sym,
+    is_terminal: bool,
     pattern: (PA, PB, PC),
     production: F,
     _phantom: SendSyncPhantomData<(V, StashValue)>,
@@ -317,6 +332,10 @@ impl<PA, PB, PC, V, StashValue, F> Rule<StashValue> for Rule3<PA, PB, PC, V, Sta
             })
             .collect()
     }
+
+    fn is_terminal(&self) -> bool {
+        self.is_terminal
+    }
 }
 
 impl<PA, PB, PC, V, StashValue, F> Rule3<PA, PB, PC, V, StashValue, F>
@@ -330,9 +349,10 @@ impl<PA, PB, PC, V, StashValue, F> Rule3<PA, PB, PC, V, StashValue, F>
           PB: Pattern<StashValue>,
           PC: Pattern<StashValue>
 {
-    pub fn new(sym: Sym, pat: (PA, PB, PC), prod: F) -> Rule3<PA, PB, PC, V, StashValue, F> {
+    pub fn new(sym: Sym, is_terminal: bool, pat: (PA, PB, PC), prod: F) -> Rule3<PA, PB, PC, V, StashValue, F> {
         Rule3 {
             sym: sym,
+            is_terminal: is_terminal,
             pattern: pat,
             production: prod,
             _phantom: SendSyncPhantomData::new(),
@@ -386,6 +406,7 @@ pub struct Rule4<PA, PB, PC, PD, V, StashValue, F>
           PD: Pattern<StashValue>,
 {
     sym: Sym,
+    is_terminal: bool,
     pattern: (PA, PB, PC, PD),
     production: F,
     _phantom: SendSyncPhantomData<(V, StashValue)>,
@@ -443,6 +464,10 @@ impl<PA, PB, PC, PD, V, StashValue, F> Rule<StashValue> for Rule4<PA, PB, PC, PD
             })
             .collect()
     }
+
+    fn is_terminal(&self) -> bool {
+        self.is_terminal
+    }
 }
 
 impl<PA, PB, PC, PD, V, StashValue, F> Rule4<PA, PB, PC, PD, V, StashValue, F>
@@ -458,9 +483,10 @@ impl<PA, PB, PC, PD, V, StashValue, F> Rule4<PA, PB, PC, PD, V, StashValue, F>
           PC: Pattern<StashValue>,
           PD: Pattern<StashValue>,
 {
-    pub fn new(sym: Sym, pat: (PA, PB, PC, PD), prod: F) -> Rule4<PA, PB, PC, PD, V, StashValue, F> {
+    pub fn new(sym: Sym, is_terminal: bool, pat: (PA, PB, PC, PD), prod: F) -> Rule4<PA, PB, PC, PD, V, StashValue, F> {
         Rule4 {
             sym: sym,
+            is_terminal: is_terminal,
             pattern: pat,
             production: prod,
             _phantom: SendSyncPhantomData::new(),
@@ -523,6 +549,7 @@ pub struct Rule5<PA, PB, PC, PD, PE, V, StashValue, F>
           PE: Pattern<StashValue>,
 {
     sym: Sym,
+    is_terminal: bool,
     pattern: (PA, PB, PC, PD, PE),
     production: F,
     _phantom: SendSyncPhantomData<(V, StashValue)>,
@@ -583,6 +610,10 @@ impl<PA, PB, PC, PD, PE, V, StashValue, F> Rule<StashValue> for Rule5<PA, PB, PC
             })
             .collect()
     }
+
+    fn is_terminal(&self) -> bool {
+        self.is_terminal
+    }
 }
 
 impl<PA, PB, PC, PD, PE, V, StashValue, F> Rule5<PA, PB, PC, PD, PE, V, StashValue, F>
@@ -600,9 +631,10 @@ impl<PA, PB, PC, PD, PE, V, StashValue, F> Rule5<PA, PB, PC, PD, PE, V, StashVal
           PD: Pattern<StashValue>,
           PE: Pattern<StashValue>,
 {
-    pub fn new(sym: Sym, pat: (PA, PB, PC, PD, PE), prod: F) -> Rule5<PA, PB, PC, PD, PE, V, StashValue, F> {
+    pub fn new(sym: Sym, is_terminal: bool, pat: (PA, PB, PC, PD, PE), prod: F) -> Rule5<PA, PB, PC, PD, PE, V, StashValue, F> {
         Rule5 {
             sym: sym,
+            is_terminal: is_terminal,
             pattern: pat,
             production: prod,
             _phantom: SendSyncPhantomData::new(),
@@ -676,6 +708,7 @@ pub struct Rule6<PA, PB, PC, PD, PE, PF, V, StashValue, F>
           PF: Pattern<StashValue>,
 {
     sym: Sym,
+    is_terminal: bool,
     pattern: (PA, PB, PC, PD, PE, PF),
     production: F,
     _phantom: SendSyncPhantomData<(V, StashValue)>,
@@ -733,6 +766,10 @@ impl<PA, PB, PC, PD, PE, PF, V, StashValue, F> Rule<StashValue> for Rule6<PA, PB
             })
             .collect()
     }
+
+    fn is_terminal(&self) -> bool {
+        self.is_terminal
+    }
 }
 
 impl<PA, PB, PC, PD, PE, PF, V, StashValue, F> Rule6<PA, PB, PC, PD, PE, PF, V, StashValue, F>
@@ -752,9 +789,10 @@ impl<PA, PB, PC, PD, PE, PF, V, StashValue, F> Rule6<PA, PB, PC, PD, PE, PF, V, 
           PE: Pattern<StashValue>,
           PF: Pattern<StashValue>,
 {
-    pub fn new(sym: Sym, pat: (PA, PB, PC, PD, PE, PF), prod: F) -> Rule6<PA, PB, PC, PD, PE, PF, V, StashValue, F> {
+    pub fn new(sym: Sym, is_terminal: bool, pat: (PA, PB, PC, PD, PE, PF), prod: F) -> Rule6<PA, PB, PC, PD, PE, PF, V, StashValue, F> {
         Rule6 {
             sym: sym,
+            is_terminal: is_terminal,
             pattern: pat,
             production: prod,
             _phantom: SendSyncPhantomData::new(),


### PR DESCRIPTION
- distinction between terminal rules and composition rules
- terminal rules are executed once at the beginning of the parsing
- composition rules are executed at each round of the parsing